### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/RumbleFrog/Dragonball.png?label=ready&title=Ready)](https://waffle.io/RumbleFrog/Dragonball)
 # Dragonball
 A repository dedicated to issue tracking for [Dragonball](https://dragonball.biturl.io "Dragonball")
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/RumbleFrog/Dragonball

This was requested by a real person (user RumbleFrog) on waffle.io, we're not trying to spam you.